### PR TITLE
Add production entrypoint script to Docker setup

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY . .
 
 RUN npm i --ignore-scripts
-RUN npx prisma db push
+RUN npx prisma generate
 
 RUN npm run build
 
@@ -26,10 +26,11 @@ COPY --from=build /app/prisma ./prisma
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/package-lock.json ./package-lock.json
 COPY --from=build /app/LICENSE ./LICENSE
+COPY --from=build /app/docker/entrypoint.prod.sh /app/entrypoint.prod.sh
 
+RUN chmod +x /app/entrypoint.prod.sh
 RUN npm ci --ignore-scripts --omit=dev
-RUN npx prisma db push
 
 EXPOSE 3000
 
-CMD ["npm", "run", "serve"]
+ENTRYPOINT ["/app/entrypoint.prod.sh"]

--- a/docker/entrypoint.prod.sh
+++ b/docker/entrypoint.prod.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+echo "⏳ Waiting for database..."
+until nc -z db 5432; do
+  sleep 1
+done
+
+echo "✅ Database available. Applying `prisma db push`..."
+npx prisma db push
+
+echo "🚀 Starting application"
+exec npm run serve


### PR DESCRIPTION
Introduces entrypoint.prod.sh to wait for the database and run Prisma migrations before starting the app. Updates Dockerfile to use the new entrypoint and replaces 'prisma db push' with 'prisma generate' during build for improved deployment reliability.