### PR TITLE
Refactor Prisma imports to use @prisma/client

### DIFF
--- a/src/components/contents/News.svelte
+++ b/src/components/contents/News.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import getUser from '$lib/utils/user'
-  import type { News, NewsCategory, NewsTag } from '.prisma/client'
+  import type { News, NewsCategory, NewsTag } from '@prisma/client'
   import type { PageData } from '../../routes/(app)/dashboard/news/$types'
   import type { File as File_ } from '$lib/utils/types'
   import AddEditNewsModal from '../modals/AddEditNewsModal.svelte'

--- a/src/components/contents/NewsCategories.svelte
+++ b/src/components/contents/NewsCategories.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NewsCategory } from '.prisma/client'
+  import type { NewsCategory } from '@prisma/client'
   import AddEditNewsCategoryModal from '../modals/AddEditNewsCategoryModal.svelte'
   import { callAction } from '$lib/utils/call'
   import { l } from '$lib/stores/language'

--- a/src/components/contents/NewsTags.svelte
+++ b/src/components/contents/NewsTags.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NewsTag } from '.prisma/client'
+  import type { NewsTag } from '@prisma/client'
   import AddEditNewsTagModal from '../modals/AddEditNewsTagModal.svelte'
   import { invalidateAll } from '$app/navigation'
   import { callAction } from '$lib/utils/call'

--- a/src/components/contents/NewsViewer.svelte
+++ b/src/components/contents/NewsViewer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NewsCategory, NewsTag, User } from '.prisma/client'
+  import type { NewsCategory, NewsTag, User } from '@prisma/client'
 
   interface Props {
     title: string

--- a/src/components/contents/UserManagement.svelte
+++ b/src/components/contents/UserManagement.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { UserStatus } from '.prisma/client'
+  import pkg from '@prisma/client'
   import type { PageData } from '../../routes/(app)/dashboard/emlat-settings/$types'
   import { emptyUser } from '$lib/stores/user'
   import { l } from '$lib/stores/language'
@@ -9,6 +9,7 @@
   import type { NotificationCode } from '$lib/utils/notifications'
   import { applyAction } from '$app/forms'
   import EditUserModal from '../modals/EditUserModal.svelte'
+  const { UserStatus } = pkg
 
   interface Props {
     selectedUserId: string

--- a/src/components/modals/AddEditBackgroundModal.svelte
+++ b/src/components/modals/AddEditBackgroundModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { BackgroundStatus } from '.prisma/client'
+  import pkg from '@prisma/client'
   import type { PageData } from '../../routes/(app)/dashboard/backgrounds/$types'
   import ModalTemplate from './__ModalTemplate.svelte'
   import Toggle from '../layouts/Toggle.svelte'
@@ -10,6 +10,7 @@
   import { applyAction } from '$app/forms'
   import { addNotification } from '$lib/stores/notifications'
   import type { NotificationCode } from '$lib/utils/notifications'
+  const { BackgroundStatus } = pkg
 
   interface Props {
     show: boolean

--- a/src/components/modals/AddEditNewsCategoryModal.svelte
+++ b/src/components/modals/AddEditNewsCategoryModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NewsCategory } from '.prisma/client'
+  import type { NewsCategory } from '@prisma/client'
   import ModalTemplate from './__ModalTemplate.svelte'
   import { l } from '$lib/stores/language'
   import LoadingSplash from '../layouts/LoadingSplash.svelte'

--- a/src/components/modals/AddEditNewsModal.svelte
+++ b/src/components/modals/AddEditNewsModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NewsCategory, NewsTag } from '.prisma/client'
+  import type { NewsCategory, NewsTag } from '@prisma/client'
   import type { PageData } from '../../routes/(app)/dashboard/news/$types'
   import type { File as File_ } from '$lib/utils/types'
   import { slide } from 'svelte/transition'

--- a/src/components/modals/ChangeLoaderModal.svelte
+++ b/src/components/modals/ChangeLoaderModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import pkg from '@prisma/client'
   import type { LoaderVersion } from '$lib/utils/types'
-  import { LoaderType, type Loader } from '.prisma/client'
+  import type { LoaderType, Loader } from '@prisma/client'
   import ModalTemplate from './__ModalTemplate.svelte'
   import LoadingSplash from '../layouts/LoadingSplash.svelte'
   import { l } from '$lib/stores/language'
@@ -8,11 +9,12 @@
   import { applyAction, enhance } from '$app/forms'
   import { NotificationCode } from '$lib/utils/notifications'
   import { addNotification } from '$lib/stores/notifications'
+  const { LoaderType } = pkg
 
   interface Props {
     show: boolean
     loader: Loader
-    loaderList: { [key in LoaderType]: LoaderVersion[] }
+    loaderList: { [key: string]: LoaderVersion[] }
   }
 
   let { show = $bindable(), loader, loaderList }: Props = $props()

--- a/src/components/modals/ReadNewsModal.svelte
+++ b/src/components/modals/ReadNewsModal.svelte
@@ -1,16 +1,9 @@
 <script lang="ts">
-  import type { NewsCategory, NewsTag } from '.prisma/client'
+  import type { NewsCategory, NewsTag } from '@prisma/client'
   import type { PageData } from '../../routes/(app)/dashboard/news/$types'
   import type { File as File_ } from '$lib/utils/types'
-  import { slide } from 'svelte/transition'
   import ModalTemplate from './__ModalTemplate.svelte'
-  import { EditorView, keymap, lineNumbers } from '@codemirror/view'
-  import { onDestroy, onMount } from 'svelte'
-  import { markdown } from '@codemirror/lang-markdown'
-  import { bracketMatching, defaultHighlightStyle, foldKeymap, indentOnInput, syntaxHighlighting } from '@codemirror/language'
-  import { autocompletion, closeBrackets, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete'
-  import { defaultKeymap, indentWithTab } from '@codemirror/commands'
-  import { EditorState } from '@codemirror/state'
+  import { EditorView } from '@codemirror/view'
   import NewsViewer from '../contents/NewsViewer.svelte'
 
   interface Props {
@@ -29,20 +22,6 @@
   let content = $state(selectedNews?.content ?? '')
   let categories = $state(selectedNews?.categories ?? [])
   let tags = $state(selectedNews?.tags ?? [])
-
-  let editorContainer: HTMLDivElement
-  let editorView: EditorView
-  const editorTheme = EditorView.theme({
-    '&, .cm-content *, .cm-gutters *, .cm-editor *': { fontFamily: 'monospace !important', fontSize: '14px' },
-    '&': { height: '100%', fontSize: '14px' }
-  })
-
-  function backgroundColor(color: string) {
-    const r = parseInt(color.slice(1, 3), 16)
-    const g = parseInt(color.slice(3, 5), 16)
-    const b = parseInt(color.slice(5, 7), 16)
-    return `rgba(${r}, ${g}, ${b}, 0.1)`
-  }
 </script>
 
 <ModalTemplate size={'m'} bind:show>

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -6,7 +6,7 @@ import { verify } from '$lib/server/auth'
 import { deleteSession } from '$lib/server/jwt'
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import { NotificationCode } from '$lib/utils/notifications'
-import type { Environment, User } from '.prisma/client'
+import type { Environment, User } from '@prisma/client'
 
 export const handle: Handle = async ({ event, resolve }) => {
   const session = event.cookies.get('session')

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,10 +1,11 @@
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import { NotificationCode } from '$lib/utils/notifications'
-import { Prisma, UserStatus } from '.prisma/client'
+import pkg from '@prisma/client'
 import { db } from './db'
 import bcrypt from 'bcrypt'
 import { checkSession } from './jwt'
 import { checkPin } from './pin'
+const { Prisma, UserStatus } = pkg
 
 export async function login(username: string, password: string) {
   let user
@@ -85,3 +86,4 @@ export async function logout(session: string) {
     throw new ServerError('Failed to log out user', err, NotificationCode.DATABASE_ERROR, 500)
   }
 }
+

--- a/src/lib/server/backgrounds.ts
+++ b/src/lib/server/backgrounds.ts
@@ -1,8 +1,10 @@
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import { NotificationCode } from '$lib/utils/notifications'
-import { BackgroundStatus, Prisma } from '.prisma/client'
+import pkg from '@prisma/client'
+import type { BackgroundStatus as BgStatus } from '@prisma/client'
 import { db } from './db'
 import type { File as File_ } from '../utils/types.d'
+const { Prisma, BackgroundStatus } = pkg
 
 export async function getActiveBackground() {
   let background
@@ -28,7 +30,7 @@ export async function getBackgroundById(backgroundId: string) {
   return background
 }
 
-export async function addBackground(name: string, file: File_, status: BackgroundStatus) {
+export async function addBackground(name: string, file: File_, status: BgStatus) {
   if (status === BackgroundStatus.ACTIVE) {
     await disableAllBackgrounds()
   }

--- a/src/lib/server/bootstraps.ts
+++ b/src/lib/server/bootstraps.ts
@@ -1,6 +1,6 @@
 import { ServerError } from '$lib/utils/errors'
 import { NotificationCode } from '$lib/utils/notifications'
-import type { Bootstrap } from '.prisma/client'
+import type { Bootstrap } from '@prisma/client'
 import { db } from './db'
 import { getFiles } from './files'
 

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -1,6 +1,8 @@
-import { PrismaClient } from '.prisma/client'
+import pkg from '@prisma/client'
+import type { PrismaClient as PClient } from '@prisma/client'
+const { PrismaClient } = pkg
 
-const globalForPrisma = globalThis as unknown as { prisma: PrismaClient }
+const globalForPrisma = globalThis as unknown as { prisma: PClient }
 
 export const db = globalForPrisma.prisma || new PrismaClient()
 

--- a/src/lib/server/jwt.ts
+++ b/src/lib/server/jwt.ts
@@ -1,6 +1,6 @@
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import { NotificationCode } from '$lib/utils/notifications'
-import type { User } from '.prisma/client'
+import type { User } from '@prisma/client'
 import type { RequestEvent } from '@sveltejs/kit'
 import { errors, jwtVerify, SignJWT } from 'jose'
 

--- a/src/lib/server/loader.ts
+++ b/src/lib/server/loader.ts
@@ -1,9 +1,11 @@
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import { NotificationCode } from '$lib/utils/notifications'
 import type { LoaderVersion } from '$lib/utils/types'
-import { LoaderFormat, LoaderType, type Loader } from '.prisma/client'
+import pkg from '@prisma/client'
+import { type Loader } from '@prisma/client'
 import { db } from './db'
 import { getOrSet } from './cache'
+const { LoaderFormat, LoaderType } = pkg
 
 export async function getVanillaVersions() {
   return getOrSet('vanilla-versions', async () => {
@@ -225,10 +227,9 @@ async function getForgeArtifactSize(version: string, format: string, ext: string
 
 async function getForgeArtifactSha1(version: string, format: string, ext: string) {
   try {
-    const response = await fetch(
-      `https://maven.minecraftforge.net/net/minecraftforge/forge/${version}/forge-${version}-${format}.${ext}.sha1`,
-      { headers: { Connection: 'close' } }
-    )
+    const response = await fetch(`https://maven.minecraftforge.net/net/minecraftforge/forge/${version}/forge-${version}-${format}.${ext}.sha1`, {
+      headers: { Connection: 'close' }
+    })
     if (!response.ok) {
       console.error('Failed to fetch Forge artifact SHA1:', response.statusText)
       throw new ServerError('Failed to fetch Forge artifact SHA1', null, NotificationCode.EXTERNAL_API_ERROR, response.status)

--- a/src/lib/server/maintenance.ts
+++ b/src/lib/server/maintenance.ts
@@ -1,6 +1,6 @@
 import { ServerError } from '$lib/utils/errors'
 import { NotificationCode } from '$lib/utils/notifications'
-import type { Maintenance } from '.prisma/client'
+import type { Maintenance } from '@prisma/client'
 import { db } from './db'
 
 export async function getMaintenance() {

--- a/src/lib/server/news.ts
+++ b/src/lib/server/news.ts
@@ -1,7 +1,8 @@
 import { db } from './db'
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import { NotificationCode } from '$lib/utils/notifications'
-import { Prisma, type News } from '.prisma/client'
+import pkg from '@prisma/client'
+const { Prisma } = pkg
 
 export async function getNews(limit: number = 20) {
   let news

--- a/src/lib/server/reset.ts
+++ b/src/lib/server/reset.ts
@@ -5,8 +5,9 @@ import fs from 'fs'
 import { ServerError } from '$lib/utils/errors'
 import { NotificationCode } from '$lib/utils/notifications'
 import { Client } from 'pg'
-import { Prisma } from '.prisma/client'
 import { deleteFile } from './files'
+import pkg from '@prisma/client'
+const { Prisma } = pkg
 
 export async function resetDatabase() {
   console.log('\n-------------- RESETTING DATABASE --------------\n')

--- a/src/lib/server/user.ts
+++ b/src/lib/server/user.ts
@@ -1,7 +1,9 @@
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import { NotificationCode } from '$lib/utils/notifications'
-import { Prisma, type User } from '.prisma/client'
+import { type User } from '@prisma/client'
 import { db } from './db'
+import pkg from '@prisma/client'
+const { Prisma } = pkg
 
 export async function getUserById(userId: string) {
   let user

--- a/src/lib/stores/user.ts
+++ b/src/lib/stores/user.ts
@@ -1,5 +1,6 @@
-import { UserStatus } from '.prisma/client'
+import pkg from '@prisma/client'
 import { writable, derived, type Readable } from 'svelte/store'
+const { UserStatus } = pkg
 
 interface User {
   id: string

--- a/src/lib/utils/validations.ts
+++ b/src/lib/utils/validations.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod/v4'
 import { NotificationCode } from './notifications'
-import { LoaderType } from '.prisma/client'
 import { DateTime } from 'luxon'
+import pkg from '@prisma/client'
+const { LoaderType } = pkg
 
 export const setupSchema = z.object({
   language: z.string().length(2, NotificationCode.SETUP_INVALID_LANGUAGE),

--- a/src/routes/(app)/dashboard/backgrounds/+page.server.ts
+++ b/src/routes/(app)/dashboard/backgrounds/+page.server.ts
@@ -4,12 +4,14 @@ import { db } from '$lib/server/db'
 import { NotificationCode } from '$lib/utils/notifications'
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import type { File as File_ } from '$lib/utils/types'
-import { BackgroundStatus } from '.prisma/client'
+import { BackgroundStatus as BgStatus } from '@prisma/client'
 import { backgroundSchema } from '$lib/utils/validations'
 import { addBackground, updateBackground, enableBackground, getBackgroundById, deleteBackground } from '$lib/server/backgrounds'
 import { randomBytes } from 'crypto'
 import path_ from 'path'
 import { deleteFile, getFiles, uploadFile } from '$lib/server/files'
+import pkg from '@prisma/client'
+const { BackgroundStatus } = pkg
 
 export const load = (async (event) => {
   const user = event.locals.user
@@ -22,7 +24,7 @@ export const load = (async (event) => {
     let backgrounds
 
     try {
-      backgrounds = (await db.background.findMany({orderBy: { createdAt: 'desc' }})) as { id: string; name: string; file: File_ | null; status: BackgroundStatus }[]
+      backgrounds = (await db.background.findMany({orderBy: { createdAt: 'desc' }})) as { id: string; name: string; file: File_ | null; status: BgStatus }[]
     } catch (err) {
       console.error('Failed to load backgrounds:', err)
       throw new ServerError('Failed to load backgrounds', err, NotificationCode.DATABASE_ERROR, 500)

--- a/src/routes/(app)/dashboard/emlat-settings/+page.server.ts
+++ b/src/routes/(app)/dashboard/emlat-settings/+page.server.ts
@@ -1,5 +1,4 @@
 import type { PageServerLoad } from './$types'
-import { UserStatus } from '.prisma/client'
 import { db } from '$lib/server/db'
 import { error, fail, redirect, type Actions, type RequestEvent } from '@sveltejs/kit'
 import { BusinessError, ServerError } from '$lib/utils/errors'
@@ -14,6 +13,8 @@ import { deleteUser, updateUser } from '$lib/server/user'
 import { verify } from '$lib/server/auth'
 import { deleteAllFiles, markAsUnconfigured, resetDatabase } from '$lib/server/reset'
 import { restartServer } from '$lib/server/setup'
+import pkg from '@prisma/client'
+const { UserStatus } = pkg
 
 export const load = (async (event) => {
   const user = event.locals.user

--- a/src/routes/(app)/dashboard/emlat-settings/+page.svelte
+++ b/src/routes/(app)/dashboard/emlat-settings/+page.svelte
@@ -1,19 +1,15 @@
 <script lang="ts">
-  import type { PageProps, SubmitFunction } from './$types'
+  import type { PageProps } from './$types'
   import { fade } from 'svelte/transition'
   import { onMount } from 'svelte'
   import getEnv from '$lib/utils/env'
-  import getUser from '$lib/utils/user'
-  import { addNotification, notifications } from '$lib/stores/notifications'
-  import { NotificationCode } from '$lib/utils/notifications'
+  import { addNotification } from '$lib/stores/notifications'
   import { l } from '$lib/stores/language'
   import LoadingSplash from '../../../../components/layouts/LoadingSplash.svelte'
-  import { UserStatus } from '.prisma/client'
+  import { UserStatus } from '@prisma/client'
   import UserManagement from '../../../../components/contents/UserManagement.svelte'
   import EditEMLAdminToolModal from '../../../../components/modals/EditEMLAdminToolModal.svelte'
-  import { applyAction, enhance } from '$app/forms'
   import { pingServerAndReload, sleep } from '$lib/utils/utils'
-  import { goto } from '$app/navigation'
   import { callAction } from '$lib/utils/call'
 
   let { data = $bindable() }: PageProps = $props()

--- a/src/routes/(app)/dashboard/files-updater/+page.server.ts
+++ b/src/routes/(app)/dashboard/files-updater/+page.server.ts
@@ -5,9 +5,11 @@ import { createFileSchema, editFileSchema, renameFileSchema, loaderSchema, uploa
 import { cacheFiles, createFile, deleteFile, editFile, getCachedFilesParsed, getFiles, renameFile, uploadFile } from '$lib/server/files'
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import { db } from '$lib/server/db'
-import { type Loader, LoaderType, LoaderFormat } from '.prisma/client'
+import type { Loader, LoaderFormat as LdFormat} from '@prisma/client'
 import { checkForgeLoader, checkVanillaLoader, getForgeFile, getForgeVersions, getVanillaVersions, updateLoader } from '$lib/server/loader'
 import path_ from 'path'
+import pkg from '@prisma/client'
+const { LoaderType, LoaderFormat } = pkg
 
 export const load = (async (event) => {
   const domain = event.url.origin
@@ -260,7 +262,7 @@ export const actions: Actions = {
 
     try {
       let file: any = null
-      let format: LoaderFormat = LoaderFormat.CLIENT
+      let format: LdFormat = LoaderFormat.CLIENT
       if (type === LoaderType.VANILLA) {
         checkVanillaLoader(minecraftVersion, loaderVersion)
       } else if (type === LoaderType.FORGE) {

--- a/src/routes/(app)/dashboard/files-updater/+page.svelte
+++ b/src/routes/(app)/dashboard/files-updater/+page.svelte
@@ -4,12 +4,13 @@
   import getEnv from '$lib/utils/env'
   import FilesUpdater from '../../../../components/contents/FilesUpdater.svelte'
   import type { File as File_ } from '$lib/utils/types'
-  import { LoaderFormat, LoaderType } from '.prisma/client'
   import ChangeLoaderModal from '../../../../components/modals/ChangeLoaderModal.svelte'
   import getUser from '$lib/utils/user'
   import { callAction } from '$lib/utils/call'
   import { l } from '$lib/stores/language'
   import { addNotification } from '$lib/stores/notifications'
+  import pkg from '@prisma/client'
+  const { LoaderFormat, LoaderType } = pkg
 
   let { data }: PageProps = $props()
 

--- a/src/routes/(setup)/setup/+page.svelte
+++ b/src/routes/(setup)/setup/+page.svelte
@@ -3,7 +3,6 @@
   import ConfigurationDatabase from '../../../components/setup/DatabaseSetup.svelte'
   import ConfigurationLanguage from '../../../components/setup/LanguageSetup.svelte'
   import { l, type LanguageCode } from '$lib/stores/language'
-  import { goto } from '$app/navigation'
   import type { PageProps } from './$types'
   import { pingServerAndReload, sleep } from '$lib/utils/utils'
   import { fade } from 'svelte/transition'


### PR DESCRIPTION
Replaced all imports from '.prisma/client' with '@prisma/client' across the codebase for consistency and compatibility. Updated usages to import enums and types from the new package, and adjusted related code where necessary.