### PR TITLE
Update output directory for Svelte adapter

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,7 @@ const config = {
     handler(warning)
   },
   kit: {
-    adapter: adapter({ out: '../dist/client' })
+    adapter: adapter({ out: '../dist' })
   }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,6 @@ import mime from 'mime-types'
 
 const filesDir = path.resolve(__dirname, 'files')
 
-
 const rawFiles = () => {
   return {
     name: 'raw-files-server',


### PR DESCRIPTION
Changed the Svelte adapter output directory from '../dist/client' to '../dist' in svelte.config.js for consistency. Also removed an unnecessary blank line in vite.config.ts.