### PR TITLE
Refactor type imports to use local db module

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,3 +1,5 @@
+//! Don't forget to update db.d.ts after editing this file
+
 generator client {
   provider      = "prisma-client-js"
   output        = "../node_modules/.prisma/client"

--- a/src/components/contents/News.svelte
+++ b/src/components/contents/News.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import getUser from '$lib/utils/user'
-  import type { News, NewsCategory, NewsTag } from '@prisma/client'
+  import type { ExtendedNews, NewsCategory, NewsTag } from '$lib/utils/db'
   import type { PageData } from '../../routes/(app)/dashboard/news/$types'
   import type { File as File_ } from '$lib/utils/types'
   import AddEditNewsModal from '../modals/AddEditNewsModal.svelte'
@@ -23,18 +23,18 @@
   let showReadNewsModal = $state(false)
   let showAddEditNewsModal = $state(false)
   let selectedNewsId: string | null = $state(null)
-  let selectedNews: News[] = $state([])
+  let selectedNews: ExtendedNews[] = $state([])
 
   let iLength = 25
   let iStart = $state(0)
 
-  function showNews(news_: News) {
+  function showNews(news_: ExtendedNews) {
     selectedNewsId = news_.id
     if (news_.authorId == user.id) showAddEditNewsModal = true
     else showReadNewsModal = true
   }
 
-  function selectNews(e: Event, news_: News) {
+  function selectNews(e: Event, news_: ExtendedNews) {
     if (user.p_news === 2 || news_.authorId == user.id) {
       e.stopPropagation()
       if ((e.target as HTMLInputElement).checked) {

--- a/src/components/contents/NewsCategories.svelte
+++ b/src/components/contents/NewsCategories.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NewsCategory } from '@prisma/client'
+  import type { NewsCategory } from '$lib/utils/db'
   import AddEditNewsCategoryModal from '../modals/AddEditNewsCategoryModal.svelte'
   import { callAction } from '$lib/utils/call'
   import { l } from '$lib/stores/language'

--- a/src/components/contents/NewsTags.svelte
+++ b/src/components/contents/NewsTags.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NewsTag } from '@prisma/client'
+  import type { NewsTag } from '$lib/utils/db'
   import AddEditNewsTagModal from '../modals/AddEditNewsTagModal.svelte'
   import { invalidateAll } from '$app/navigation'
   import { callAction } from '$lib/utils/call'

--- a/src/components/contents/NewsViewer.svelte
+++ b/src/components/contents/NewsViewer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NewsCategory, NewsTag, User } from '@prisma/client'
+  import type { NewsCategory, NewsTag } from '$lib/utils/db'
 
   interface Props {
     title: string

--- a/src/components/contents/UserManagement.svelte
+++ b/src/components/contents/UserManagement.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import pkg from '@prisma/client'
+  import { IUserStatus } from '$lib/utils/db'
   import type { PageData } from '../../routes/(app)/dashboard/emlat-settings/$types'
   import { emptyUser } from '$lib/stores/user'
   import { l } from '$lib/stores/language'
@@ -9,7 +9,6 @@
   import type { NotificationCode } from '$lib/utils/notifications'
   import { applyAction } from '$app/forms'
   import EditUserModal from '../modals/EditUserModal.svelte'
-  const { UserStatus } = pkg
 
   interface Props {
     selectedUserId: string
@@ -55,7 +54,7 @@
   <EditUserModal bind:show={showEditUserModal} bind:selectedUserId {action} {data} />
 {/if}
 
-{#if !selectedUser.isAdmin && selectedUser.status === UserStatus.ACTIVE}
+{#if !selectedUser.isAdmin && selectedUser.status === IUserStatus.ACTIVE}
   <form method="POST" action="?/deleteUser" use:enhance={enhanceForm}>
     <button type="submit" class="secondary right refuse" aria-label="Delete user"><i class="fa-solid fa-trash"></i></button>
   </form>
@@ -69,7 +68,7 @@
   >
     <i class="fa-solid fa-pen"></i>
   </button>
-{:else if selectedUser.status === UserStatus.PENDING}
+{:else if selectedUser.status === IUserStatus.PENDING}
   <form method="POST" action="?/refuseUser" use:enhance={enhanceForm}>
     <button type="submit" class="secondary right refuse" aria-label="Refuse user"><i class="fa-solid fa-times"></i></button>
   </form>
@@ -83,7 +82,7 @@
   >
     <i class="fa-solid fa-check"></i>
   </button>
-{:else if selectedUser.status && (selectedUser.status === UserStatus.DELETED || selectedUser.status === UserStatus.SPAM)}
+{:else if selectedUser.status && (selectedUser.status === IUserStatus.DELETED || selectedUser.status === IUserStatus.SPAM)}
   <form method="POST" action="?/deleteUserForever" use:enhance={enhanceForm}>
     <button type="submit" class="secondary right delete" aria-label="Delete user forever"><i class="fa-solid fa-trash"></i></button>
   </form>
@@ -95,7 +94,7 @@
   <p class="label">{$l.main.username}</p>
   <p>{selectedUser.username}</p>
 
-  {#if selectedUser.status === UserStatus.ACTIVE}
+  {#if selectedUser.status === IUserStatus.ACTIVE}
     <p class="label">{$l.dashboard.permissions}</p>
     {#if selectedUser.isAdmin}
       <p>Admin (all permissions)</p>

--- a/src/components/modals/AddEditBackgroundModal.svelte
+++ b/src/components/modals/AddEditBackgroundModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import pkg from '@prisma/client'
+  import { IBackgroundStatus } from '$lib/utils/db'
   import type { PageData } from '../../routes/(app)/dashboard/backgrounds/$types'
   import ModalTemplate from './__ModalTemplate.svelte'
   import Toggle from '../layouts/Toggle.svelte'
@@ -10,7 +10,6 @@
   import { applyAction } from '$app/forms'
   import { addNotification } from '$lib/stores/notifications'
   import type { NotificationCode } from '$lib/utils/notifications'
-  const { BackgroundStatus } = pkg
 
   interface Props {
     show: boolean
@@ -24,8 +23,8 @@
 
   let selectedBackground = $state(backgrounds.find((b) => b.id === selectedBackgroundId) ?? null)
   let name = $state(selectedBackground?.name ?? '')
-  let status = $state(selectedBackground?.status === BackgroundStatus.ACTIVE)
-  let disableStatus = $state(selectedBackground?.status === BackgroundStatus.ACTIVE)
+  let status = $state(selectedBackground?.status === IBackgroundStatus.ACTIVE)
+  let disableStatus = $state(selectedBackground?.status === IBackgroundStatus.ACTIVE)
   let fileName = $state('')
   let file: File | null = $state(null)
 
@@ -53,7 +52,7 @@
   const enhanceForm: SubmitFunction = ({ formData }) => {
     showLoader = true
     formData.set('background-id', selectedBackgroundId ?? '')
-    formData.set('status', status ? BackgroundStatus.ACTIVE : BackgroundStatus.INACTIVE)
+    formData.set('status', status ? IBackgroundStatus.ACTIVE : IBackgroundStatus.INACTIVE)
     formData.set('file', file ?? '')
 
     return async ({ result, update }) => {

--- a/src/components/modals/AddEditNewsCategoryModal.svelte
+++ b/src/components/modals/AddEditNewsCategoryModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NewsCategory } from '@prisma/client'
+  import type { NewsCategory } from '$lib/utils/db'
   import ModalTemplate from './__ModalTemplate.svelte'
   import { l } from '$lib/stores/language'
   import LoadingSplash from '../layouts/LoadingSplash.svelte'

--- a/src/components/modals/AddEditNewsModal.svelte
+++ b/src/components/modals/AddEditNewsModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NewsCategory, NewsTag } from '@prisma/client'
+  import type { NewsCategory, NewsTag } from '$lib/utils/db'
   import type { PageData } from '../../routes/(app)/dashboard/news/$types'
   import type { File as File_ } from '$lib/utils/types'
   import { slide } from 'svelte/transition'

--- a/src/components/modals/ChangeLoaderModal.svelte
+++ b/src/components/modals/ChangeLoaderModal.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import pkg from '@prisma/client'
+  import { ILoaderType, type LoaderType, type Loader } from '$lib/utils/db'
   import type { LoaderVersion } from '$lib/utils/types'
-  import type { LoaderType, Loader } from '@prisma/client'
   import ModalTemplate from './__ModalTemplate.svelte'
   import LoadingSplash from '../layouts/LoadingSplash.svelte'
   import { l } from '$lib/stores/language'
@@ -9,7 +8,6 @@
   import { applyAction, enhance } from '$app/forms'
   import { NotificationCode } from '$lib/utils/notifications'
   import { addNotification } from '$lib/stores/notifications'
-  const { LoaderType } = pkg
 
   interface Props {
     show: boolean
@@ -22,7 +20,7 @@
   const latestInfo = 'Choosing this version will always force the Launcher to download the latest release.'
 
   let showLoader = $state(false)
-  let type: LoaderType = $state(loader.type ?? LoaderType.VANILLA)
+  let type: LoaderType = $state(loader.type ?? ILoaderType.VANILLA)
   let minecraftVersion = $state(loader.minecraftVersion ?? '')
   let minecraftMajorVersion = $state(
     loader.minecraftVersion?.includes('latest') ? 'Latest' : (loader.minecraftVersion?.split('.').slice(0, 2).join('.') ?? '')
@@ -46,7 +44,7 @@
 
   function setVersion(selectedType: LoaderType, selectedVersion: LoaderVersion) {
     type = selectedType
-    minecraftVersion = type === LoaderType.VANILLA ? selectedVersion.loaderVersion : selectedVersion.loaderVersion.split('-')[0].replace('_', '-')
+    minecraftVersion = type === ILoaderType.VANILLA ? selectedVersion.loaderVersion : selectedVersion.loaderVersion.split('-')[0].replace('_', '-')
     loaderVersion = selectedVersion.loaderVersion
   }
 
@@ -93,8 +91,9 @@
     <div class="list-container">
       <div class="list loader-list">
         <p class="label" style="margin-top: 0; position: sticky; top: 0; background: white">Loaders</p>
-        <button class="list" type="button" class:active={type === LoaderType.VANILLA} onclick={() => switchType(LoaderType.VANILLA)}>Vanilla</button>
-        <button class="list" type="button" class:active={type === LoaderType.FORGE} onclick={() => switchType(LoaderType.FORGE)}>Forge</button>
+        <button class="list" type="button" class:active={type === ILoaderType.VANILLA} onclick={() => switchType(ILoaderType.VANILLA)}>Vanilla</button
+        >
+        <button class="list" type="button" class:active={type === ILoaderType.FORGE} onclick={() => switchType(ILoaderType.FORGE)}>Forge</button>
       </div>
 
       <div class="list version-list">
@@ -108,20 +107,20 @@
 
       <div class="list content-list">
         <h4>
-          {type === LoaderType.FORGE ? 'Minecraft Forge' : 'Minecraft Vanilla'}
+          {type === ILoaderType.FORGE ? 'Minecraft Forge' : 'Minecraft Vanilla'}
           {minecraftMajorVersion === 'Latest' ? minecraftMajorVersion : `${minecraftMajorVersion}.x`}
         </h4>
 
-        {#if type === LoaderType.VANILLA}
+        {#if type === ILoaderType.VANILLA}
           <!--* VANILLA -->
           <p class="label">Releases</p>
           {#each loaderList[type].filter((l) => l.minecraftVersion === minecraftMajorVersion && l.type.includes('release')) as version}
             {#if version.loaderVersion === 'latest_release'}
-              <button type="button" class:active={isActive(LoaderType.VANILLA, version)} onclick={() => setVersion(LoaderType.VANILLA, version)}>
+              <button type="button" class:active={isActive(ILoaderType.VANILLA, version)} onclick={() => setVersion(ILoaderType.VANILLA, version)}>
                 Latest Minecraft release&nbsp;&nbsp;<i class="fa-solid fa-circle-question" title={latestInfo} style="cursor: help"></i>
               </button>
             {:else}
-              <button type="button" class:active={isActive(LoaderType.VANILLA, version)} onclick={() => setVersion(LoaderType.VANILLA, version)}>
+              <button type="button" class:active={isActive(ILoaderType.VANILLA, version)} onclick={() => setVersion(ILoaderType.VANILLA, version)}>
                 Minecraft {version.loaderVersion}
               </button>
             {/if}
@@ -130,22 +129,22 @@
           <p class="label">Snapshots</p>
           {#each loaderList[type].filter((l) => l.minecraftVersion === minecraftMajorVersion && l.type.includes('snapshot')) as version}
             {#if version.loaderVersion === 'latest_snapshot'}
-              <button type="button" class:active={isActive(LoaderType.VANILLA, version)} onclick={() => setVersion(LoaderType.VANILLA, version)}>
+              <button type="button" class:active={isActive(ILoaderType.VANILLA, version)} onclick={() => setVersion(ILoaderType.VANILLA, version)}>
                 Latest Minecraft snapshot&nbsp;&nbsp;<i class="fa-solid fa-circle-question" title={latestInfo} style="cursor: help"></i>
               </button>
             {:else}
-              <button type="button" class:active={isActive(LoaderType.VANILLA, version)} onclick={() => setVersion(LoaderType.VANILLA, version)}>
+              <button type="button" class:active={isActive(ILoaderType.VANILLA, version)} onclick={() => setVersion(ILoaderType.VANILLA, version)}>
                 Minecraft {version.loaderVersion}
               </button>
             {/if}
           {:else}
             <p class="no-link">-</p>
           {/each}
-        {:else if type === LoaderType.FORGE}
+        {:else if type === ILoaderType.FORGE}
           <!--* FORGE -->
           <p class="label">Recommended</p>
           {#each loaderList[type].filter((l) => l.minecraftVersion === minecraftMajorVersion && l.type.includes('recommended')) as version}
-            <button type="button" class:active={isActive(LoaderType.FORGE, version)} onclick={() => setVersion(LoaderType.FORGE, version)}>
+            <button type="button" class:active={isActive(ILoaderType.FORGE, version)} onclick={() => setVersion(ILoaderType.FORGE, version)}>
               Minecraft {version.loaderVersion.split('-')[0].replace('_', '-')} (Forge {version.loaderVersion.split('-').slice(1).join('-')})
             </button>
           {:else}
@@ -154,7 +153,7 @@
 
           <p class="label">Latest</p>
           {#each loaderList[type].filter((l) => l.minecraftVersion === minecraftMajorVersion && l.type.includes('latest')) as version}
-            <button type="button" class:active={isActive(LoaderType.FORGE, version)} onclick={() => setVersion(LoaderType.FORGE, version)}>
+            <button type="button" class:active={isActive(ILoaderType.FORGE, version)} onclick={() => setVersion(ILoaderType.FORGE, version)}>
               Minecraft {version.loaderVersion.split('-')[0].replace('_', '-')} (Forge {version.loaderVersion.split('-').slice(1).join('-')})
             </button>
           {:else}
@@ -163,7 +162,7 @@
 
           <p class="label">All versions</p>
           {#each loaderList[type].filter((l) => l.minecraftVersion === minecraftMajorVersion) as version}
-            <button type="button" class:active={isActive(LoaderType.FORGE, version)} onclick={() => setVersion(LoaderType.FORGE, version)}>
+            <button type="button" class:active={isActive(ILoaderType.FORGE, version)} onclick={() => setVersion(ILoaderType.FORGE, version)}>
               Minecraft {version.loaderVersion.split('-')[0].replace('_', '-')} (Forge {version.loaderVersion.split('-').slice(1).join('-')})
             </button>
           {:else}

--- a/src/components/modals/ReadNewsModal.svelte
+++ b/src/components/modals/ReadNewsModal.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-  import type { NewsCategory, NewsTag } from '@prisma/client'
+  import type { NewsCategory, NewsTag } from '$lib/utils/db'
   import type { PageData } from '../../routes/(app)/dashboard/news/$types'
   import type { File as File_ } from '$lib/utils/types'
   import ModalTemplate from './__ModalTemplate.svelte'
-  import { EditorView } from '@codemirror/view'
   import NewsViewer from '../contents/NewsViewer.svelte'
 
   interface Props {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -6,7 +6,7 @@ import { verify } from '$lib/server/auth'
 import { deleteSession } from '$lib/server/jwt'
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import { NotificationCode } from '$lib/utils/notifications'
-import type { Environment, User } from '@prisma/client'
+import { type User } from '$lib/utils/db'
 
 export const handle: Handle = async ({ event, resolve }) => {
   const session = event.cookies.get('session')
@@ -82,8 +82,3 @@ function getUserInfo(user: User) {
   }
 }
 
-async function setEnv(env?: Environment) {
-  if (env) {
-    return {}
-  }
-}

--- a/src/lib/stores/user.ts
+++ b/src/lib/stores/user.ts
@@ -1,6 +1,5 @@
-import pkg from '@prisma/client'
+import { IUserStatus } from '$lib/utils/db'
 import { writable, derived, type Readable } from 'svelte/store'
-const { UserStatus } = pkg
 
 interface User {
   id: string
@@ -26,7 +25,7 @@ export const emptyUser = {
   id: '0',
   username: '',
   isAdmin: false,
-  status: UserStatus.ACTIVE,
+  status: IUserStatus.ACTIVE,
   p_filesUpdater: 0,
   p_bootstraps: 0,
   p_maintenance: 0,
@@ -38,3 +37,4 @@ export const emptyUser = {
   createdAt: new Date(),
   updatedAt: new Date()
 }
+

--- a/src/lib/utils/db.ts
+++ b/src/lib/utils/db.ts
@@ -1,0 +1,187 @@
+import type { File as File_ } from './types'
+
+export const IUserStatus = {
+  /**
+   * The user is active and can log in.
+   */
+  ACTIVE: 'ACTIVE',
+  /**
+   * The user is pending for approval and **can** log in.
+   */
+  PENDING: 'PENDING',
+  /**
+   * The user is flagged as spam (wrong PIN) and **can** log in.
+   */
+  SPAM: 'SPAM',
+  /**
+   * The user is deleted and **cannot** log in.
+   */
+  DELETED: 'DELETED'
+} as const
+
+export const ILoaderType = {
+  VANILLA: 'VANILLA',
+  FORGE: 'FORGE'
+} as const
+
+export const ILoaderFormat = {
+  INSTALLER: 'INSTALLER',
+  UNIVERSAL: 'UNIVERSAL',
+  CLIENT: 'CLIENT'
+} as const
+
+export const IBackgroundStatus = {
+  ACTIVE: 'ACTIVE',
+  INACTIVE: 'INACTIVE'
+} as const
+
+export const IStatAction = {
+  STARTUP: 'STARTUP',
+  LOGIN: 'LOGIN',
+  LAUNCH: 'LAUNCH',
+  DEVTOOLS: 'DEVTOOLS'
+} as const
+
+export type UserStatus = (typeof IUserStatus)[keyof typeof IUserStatus]
+export type LoaderType = (typeof ILoaderType)[keyof typeof ILoaderType]
+export type LoaderFormat = (typeof ILoaderFormat)[keyof typeof ILoaderFormat]
+export type BackgroundStatus = (typeof IBackgroundStatus)[keyof typeof IBackgroundStatus]
+export type StatAction = (typeof IStatAction)[keyof typeof IStatAction]
+
+export interface Environment {
+  id: string
+  language: string
+  name: string
+  theme: string
+  pin: string
+  updatedAt: Date
+}
+
+export interface User {
+  id: string
+  username: string
+  /**
+   * **Never send this field to the client.**
+   */
+  password?: string
+  status: UserStatus
+  isAdmin: boolean
+  /**
+   * `0` — no access, `1` — write files, `2` — read and write files, and change loader
+   */
+  p_filesUpdater: number
+  /**
+   * `0` — no access, `1` — write
+   */
+  p_bootstraps: number
+  /**
+   * `0` — no access, `1` — write
+   */
+  p_maintenance: number
+  /**
+   * `0` — no access, `1` — write news and delete their own news, `2` — write news and delete any news
+   */
+  p_news: number
+  /**
+   * `0` — no access, `1` — write
+   */
+  p_newsCategories: number
+  /**
+   * `0` — no access, `1` — write
+   */
+  p_newsTags: number
+  /**
+   * `0` — no access, `1` — write
+   */
+  p_backgrounds: number
+  /**
+   * `0` — no access, `1` — read, `2` — read and reset
+   */
+  p_stats: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface Log {
+  id: string
+  userId?: string
+  action: StatAction
+  details?: string
+  timestamp: Date
+}
+
+export interface Loader {
+  id: string
+  type: LoaderType
+  minecraftVersion: string
+  loaderVersion: string
+  format: LoaderFormat
+  file?: File_ | null
+  updatedAt: Date
+}
+
+export interface Bootstrap {
+  id: string
+  winFile: File_
+  macFile: File_
+  linFile: File_
+  version: string
+  updatedAt: Date
+}
+
+export interface Maintenance {
+  id: string
+  startTime?: Date
+  endTime?: Date
+  message: string
+}
+
+export interface News {
+  id: string
+  title: string
+  content: string
+  authorId: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface NewsCategory {
+  id: string
+  name: string
+  createdAt: Date
+}
+
+export interface NewsTag {
+  id: string
+  name: string
+  color: string
+}
+
+export interface Background {
+  id: string
+  name: string
+  file: File_
+  status: BackgroundStatus
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface Stat {
+  id: string
+  action: StatAction
+  value?: string
+  createdAt: Date
+}
+
+export interface ExpiredToken {
+  id: string
+  token: string
+  expiredAt: Date
+}
+
+export type ExtendedNews = News & {
+  author: { id: string; username: string }
+  categories: { name: string; id: string; createdAt: Date }[]
+  tags: { name: string; id: string; color: string }[]
+}
+

--- a/src/lib/utils/validations.ts
+++ b/src/lib/utils/validations.ts
@@ -1,8 +1,7 @@
 import { z } from 'zod/v4'
 import { NotificationCode } from './notifications'
 import { DateTime } from 'luxon'
-import pkg from '@prisma/client'
-const { LoaderType } = pkg
+import { ILoaderType } from '$lib/utils/db'
 
 export const setupSchema = z.object({
   language: z.string().length(2, NotificationCode.SETUP_INVALID_LANGUAGE),
@@ -113,7 +112,7 @@ export const editFileSchema = z.object({
 })
 
 export const loaderSchema = z.object({
-  type: z.enum(LoaderType),
+  type: z.enum(ILoaderType),
   minecraftVersion: z.string(),
   loaderVersion: z.string()
 })

--- a/src/routes/(app)/dashboard/backgrounds/+page.server.ts
+++ b/src/routes/(app)/dashboard/backgrounds/+page.server.ts
@@ -4,14 +4,12 @@ import { db } from '$lib/server/db'
 import { NotificationCode } from '$lib/utils/notifications'
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import type { File as File_ } from '$lib/utils/types'
-import { BackgroundStatus as BgStatus } from '@prisma/client'
+import { type BackgroundStatus, IBackgroundStatus } from '$lib/utils/db'
 import { backgroundSchema } from '$lib/utils/validations'
 import { addBackground, updateBackground, enableBackground, getBackgroundById, deleteBackground } from '$lib/server/backgrounds'
 import { randomBytes } from 'crypto'
 import path_ from 'path'
 import { deleteFile, getFiles, uploadFile } from '$lib/server/files'
-import pkg from '@prisma/client'
-const { BackgroundStatus } = pkg
 
 export const load = (async (event) => {
   const user = event.locals.user
@@ -24,7 +22,7 @@ export const load = (async (event) => {
     let backgrounds
 
     try {
-      backgrounds = (await db.background.findMany({orderBy: { createdAt: 'desc' }})) as { id: string; name: string; file: File_ | null; status: BgStatus }[]
+      backgrounds = (await db.background.findMany({orderBy: { createdAt: 'desc' }})) as { id: string; name: string; file: File_ | null; status: BackgroundStatus }[]
     } catch (err) {
       console.error('Failed to load backgrounds:', err)
       throw new ServerError('Failed to load backgrounds', err, NotificationCode.DATABASE_ERROR, 500)
@@ -72,9 +70,9 @@ export const actions: Actions = {
         }
 
         const newStatus =
-          status === BackgroundStatus.ACTIVE || existingBackground.status === BackgroundStatus.ACTIVE
-            ? BackgroundStatus.ACTIVE
-            : BackgroundStatus.INACTIVE
+          status === IBackgroundStatus.ACTIVE || existingBackground.status === IBackgroundStatus.ACTIVE
+            ? IBackgroundStatus.ACTIVE
+            : IBackgroundStatus.INACTIVE
         
         if (newStatus !== existingBackground.status) {
           await enableBackground(backgroundId)
@@ -163,6 +161,7 @@ export const actions: Actions = {
     }
   }
 }
+
 
 
 

--- a/src/routes/(app)/dashboard/emlat-settings/+page.server.ts
+++ b/src/routes/(app)/dashboard/emlat-settings/+page.server.ts
@@ -13,8 +13,7 @@ import { deleteUser, updateUser } from '$lib/server/user'
 import { verify } from '$lib/server/auth'
 import { deleteAllFiles, markAsUnconfigured, resetDatabase } from '$lib/server/reset'
 import { restartServer } from '$lib/server/setup'
-import pkg from '@prisma/client'
-const { UserStatus } = pkg
+import { IUserStatus } from '$lib/utils/db'
 
 export const load = (async (event) => {
   const user = event.locals.user
@@ -136,7 +135,7 @@ export const actions: Actions = {
 
     const userId = result.data.userId
     const username = result.data.username
-    const status = UserStatus.ACTIVE
+    const status = IUserStatus.ACTIVE
     const p_filesUpdater = getFilesUpdaterPermission(result)
     const p_bootstraps = result.data.p_bootstraps ? 1 : 0
     const p_maintenance = result.data.p_maintenance ? 1 : 0
@@ -246,7 +245,7 @@ async function refuseDeleteUser(event: RequestEvent<Partial<Record<string, strin
 
   try {
     await updateUser(userId, {
-      status: UserStatus.DELETED,
+      status: IUserStatus.DELETED,
       p_filesUpdater: 0,
       p_bootstraps: 0,
       p_maintenance: 0,
@@ -282,4 +281,5 @@ function getStatsPermissions(result: any) {
   if (result.data.p_stats_1) return 1
   return 0
 }
+
 

--- a/src/routes/(app)/dashboard/emlat-settings/+page.svelte
+++ b/src/routes/(app)/dashboard/emlat-settings/+page.svelte
@@ -6,7 +6,7 @@
   import { addNotification } from '$lib/stores/notifications'
   import { l } from '$lib/stores/language'
   import LoadingSplash from '../../../../components/layouts/LoadingSplash.svelte'
-  import { UserStatus } from '@prisma/client'
+  import { IUserStatus } from '$lib/utils/db'
   import UserManagement from '../../../../components/contents/UserManagement.svelte'
   import EditEMLAdminToolModal from '../../../../components/modals/EditEMLAdminToolModal.svelte'
   import { pingServerAndReload, sleep } from '$lib/utils/utils'
@@ -159,7 +159,7 @@ Please note that EML AdminTool, and therefore the Launchers too, will be unavail
     <div class="list">
       <p class="label">{$l.dashboard.emlatSettings.users}</p>
       {#each data.users as u}
-        {#if u.status === UserStatus.ACTIVE}
+        {#if u.status === IUserStatus.ACTIVE}
           <button class="list" class:active={selectedUserId === u.id} onclick={() => (selectedUserId = u.id)}>
             {u.username}
           </button>
@@ -168,7 +168,7 @@ Please note that EML AdminTool, and therefore the Launchers too, will be unavail
 
       <p class="label">{$l.dashboard.emlatSettings.pendingUsers}</p>
       {#each data.users as u}
-        {#if u.status === UserStatus.PENDING}
+        {#if u.status === IUserStatus.PENDING}
           <button class="list" class:active={selectedUserId === u.id} onclick={() => (selectedUserId = u.id)}>
             {u.username}
           </button>
@@ -177,7 +177,7 @@ Please note that EML AdminTool, and therefore the Launchers too, will be unavail
 
       <p class="label">{$l.dashboard.emlatSettings.wrongPinUsers}</p>
       {#each data.users as u}
-        {#if u.status === UserStatus.SPAM}
+        {#if u.status === IUserStatus.SPAM}
           <button class="list" class:active={selectedUserId === u.id} onclick={() => (selectedUserId = u.id)}>
             {u.username}
           </button>
@@ -186,7 +186,7 @@ Please note that EML AdminTool, and therefore the Launchers too, will be unavail
 
       <p class="label">{$l.dashboard.emlatSettings.deletedUsers}</p>
       {#each data.users as u}
-        {#if u.status === UserStatus.DELETED}
+        {#if u.status === IUserStatus.DELETED}
           <button class="list" class:active={selectedUserId === u.id} onclick={() => (selectedUserId = u.id)}>
             {u.username}
           </button>

--- a/src/routes/(app)/dashboard/files-updater/+page.server.ts
+++ b/src/routes/(app)/dashboard/files-updater/+page.server.ts
@@ -5,11 +5,9 @@ import { createFileSchema, editFileSchema, renameFileSchema, loaderSchema, uploa
 import { cacheFiles, createFile, deleteFile, editFile, getCachedFilesParsed, getFiles, renameFile, uploadFile } from '$lib/server/files'
 import { BusinessError, ServerError } from '$lib/utils/errors'
 import { db } from '$lib/server/db'
-import type { Loader, LoaderFormat as LdFormat} from '@prisma/client'
+import { ILoaderFormat, ILoaderType, type Loader, type LoaderFormat } from '$lib/utils/db'
 import { checkForgeLoader, checkVanillaLoader, getForgeFile, getForgeVersions, getVanillaVersions, updateLoader } from '$lib/server/loader'
 import path_ from 'path'
-import pkg from '@prisma/client'
-const { LoaderType, LoaderFormat } = pkg
 
 export const load = (async (event) => {
   const domain = event.url.origin
@@ -33,17 +31,18 @@ export const load = (async (event) => {
     if (!loader?.loaderVersion) {
       loader = {
         id: '',
-        type: LoaderType.VANILLA,
+        type: ILoaderType.VANILLA,
         minecraftVersion: 'latest_release',
         loaderVersion: 'latest_release',
-        format: LoaderFormat.CLIENT,
-        file: null
+        format: ILoaderFormat.CLIENT,
+        file: null,
+        updatedAt: new Date()
       } as Loader
     }
 
     const loaderList = {
-      [LoaderType.VANILLA]: await getVanillaVersions(),
-      [LoaderType.FORGE]: await getForgeVersions()
+      [ILoaderType.VANILLA]: await getVanillaVersions(),
+      [ILoaderType.FORGE]: await getForgeVersions()
     }
 
     return { loader, loaderList, files }
@@ -262,10 +261,10 @@ export const actions: Actions = {
 
     try {
       let file: any = null
-      let format: LdFormat = LoaderFormat.CLIENT
-      if (type === LoaderType.VANILLA) {
+      let format: LoaderFormat = ILoaderFormat.CLIENT
+      if (type === ILoaderType.VANILLA) {
         checkVanillaLoader(minecraftVersion, loaderVersion)
-      } else if (type === LoaderType.FORGE) {
+      } else if (type === ILoaderType.FORGE) {
         checkForgeLoader(minecraftVersion, loaderVersion)
         const res = await getForgeFile(loaderVersion)
         file = res.file

--- a/src/routes/(app)/dashboard/files-updater/+page.svelte
+++ b/src/routes/(app)/dashboard/files-updater/+page.svelte
@@ -9,8 +9,7 @@
   import { callAction } from '$lib/utils/call'
   import { l } from '$lib/stores/language'
   import { addNotification } from '$lib/stores/notifications'
-  import pkg from '@prisma/client'
-  const { LoaderFormat, LoaderType } = pkg
+  import { ILoaderFormat, ILoaderType, type Loader } from '$lib/utils/db'
 
   let { data }: PageProps = $props()
 
@@ -156,7 +155,7 @@
 </svelte:head>
 
 {#if showChangeLoaderModal}
-  <ChangeLoaderModal bind:show={showChangeLoaderModal} loader={data.loader} loaderList={data.loaderList} />
+  <ChangeLoaderModal bind:show={showChangeLoaderModal} loader={data.loader as unknown as Loader} loaderList={data.loaderList} />
 {/if}
 
 <h2>Files Updater</h2>
@@ -216,7 +215,7 @@
       <div>
         <p class="label">Loader</p>
         <p>
-          {data.loader.type === LoaderType.FORGE ? 'Forge' : 'Vanilla'}
+          {data.loader.type === ILoaderType.FORGE ? 'Forge' : 'Vanilla'}
         </p>
       </div>
 
@@ -239,7 +238,7 @@
             style="cursor: help"
           ></i>
         </p>
-        <p>{data.loader.format === LoaderFormat.INSTALLER ? 'Installer' : data.loader.format === LoaderFormat.UNIVERSAL ? 'Universal' : 'Client'}</p>
+        <p>{data.loader.format === ILoaderFormat.INSTALLER ? 'Installer' : data.loader.format === ILoaderFormat.UNIVERSAL ? 'Universal' : 'Client'}</p>
       </div>
     </div>
   </section>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -18,5 +18,3 @@ const config = {
 
 export default config
 
-
-


### PR DESCRIPTION
Replaced all imports from '@prisma/client' for enums and types with equivalents from a new '$lib/utils/db' module. This centralizes type definitions and enums, improves maintainability, and removes direct dependency on Prisma types in frontend and validation code. Also added the new db.ts file containing all shared types and enums.